### PR TITLE
IllegalValue str broken

### DIFF
--- a/barely_json/__init__.py
+++ b/barely_json/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-"""
+'''
 A very forgiving JSON parser.
-"""
+'''
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
@@ -19,7 +19,7 @@ __version__ = '0.1.1'
 
 
 class IllegalValue(object):
-    """
+    '''
     A value that is illegal in JSON.
 
     ``parse`` wraps anything that isn't standard JSON into an
@@ -31,13 +31,13 @@ class IllegalValue(object):
     The part of the source that is represented by this instance is
     stored in the ``source`` attribute. That may be the empty string in
     cases like ``[1, , 2]``.
-    """
+    '''
     def __init__(self, source):
-        """
+        '''
         Constructor.
 
         ``source`` is a string.
-        """
+        '''
         self.source = source
 
     def __str__(self):
@@ -55,16 +55,16 @@ class IllegalValue(object):
 
 
 def to_float(t):
-    """
+    '''
     Convert a string that looks like a float to a float.
-    """
+    '''
     return float(re.sub(r'\s*', '', t[0]))
 
 
 def to_int(t):
-    """
+    '''
     Convert a string that looks like an int to an int.
-    """
+    '''
     return int(re.sub(r'\s*', '', t[0]))
 
 
@@ -81,9 +81,9 @@ ESCAPE_SEQUENCE_RE = re.compile(r'''
 
 
 def decode_escapes(s):
-    """
+    '''
     Decode string escape sequences.
-    """
+    '''
     def decode_match(match):
         return codecs.decode(match.group(0), 'unicode-escape')
     result = ESCAPE_SEQUENCE_RE.sub(decode_match, s)
@@ -136,8 +136,8 @@ value << (dict_ | list_ | float_ | int_ | string_ |
           null | true | false | illegal)
 
 
-def default_resolver(value_):
-    """
+def default_resolver(value):
+    '''
     Default resolver for illegal values.
 
     Case-insensitively resolves
@@ -152,8 +152,8 @@ def default_resolver(value_):
       counterparts
 
     All other strings are returned unchanged.
-    """
-    low = value_.lower()
+    '''
+    low = value.lower()
     if low in ['true', 'yes', 'on']:
         return True
     if low in ['false', 'no', 'off']:
@@ -165,11 +165,11 @@ def default_resolver(value_):
         return float(re.sub(r'\s+', '', low))
     except ValueError:
         pass
-    return decode_escapes(value_)
+    return decode_escapes(value)
 
 
 def resolve(data, resolver=default_resolver):
-    """
+    '''
     Recursively resolve illegal values.
 
     ``data`` is a potentially nested Python value as returned by
@@ -179,25 +179,25 @@ def resolve(data, resolver=default_resolver):
 
     All instances of ``IllegalValue`` in ``data`` are replaced by the
     result of feeding them into ``resolver``.
-    """
+    '''
     if isinstance(data, list):
         return [resolve(item, resolver) for item in data]
     if isinstance(data, dict):
-        return {resolve(key, resolver): resolve(value_, resolver) for key, value_ in iteritems(data)}
+        return {resolve(key, resolver): resolve(value, resolver) for key, value in iteritems(data)}
     if isinstance(data, IllegalValue):
         return resolver(data.source)
     return data
 
 
 def parse(s, resolver=default_resolver):
-    """
+    '''
     Parse a string that contains barely JSON.
 
     When values that are illegal in JSON are encountered then they are
     by default heuristicaly resolved to a suitable Python type (see
     ``resolve`` and ``default_resolver``). Set ``resolver`` to a custom
     callback or to a falsy value to modify or disable that mechanism.
-    """
+    '''
     parsed = value.parseString(s, parseAll=True)
     data = parsed.asList()[0]
     if resolver:

--- a/barely_json/__init__.py
+++ b/barely_json/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-'''
+"""
 A very forgiving JSON parser.
-'''
+"""
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
@@ -19,7 +19,7 @@ __version__ = '0.1.1'
 
 
 class IllegalValue(object):
-    '''
+    """
     A value that is illegal in JSON.
 
     ``parse`` wraps anything that isn't standard JSON into an
@@ -31,17 +31,17 @@ class IllegalValue(object):
     The part of the source that is represented by this instance is
     stored in the ``source`` attribute. That may be the empty string in
     cases like ``[1, , 2]``.
-    '''
+    """
     def __init__(self, source):
-        '''
+        """
         Constructor.
 
         ``source`` is a string.
-        '''
+        """
         self.source = source
 
     def __str__(self):
-        return source
+        return self.source
 
     def __repr__(self):
         return '<{} {!r}>'.format(self.__class__.__name__, self.source)
@@ -55,16 +55,16 @@ class IllegalValue(object):
 
 
 def to_float(t):
-    '''
+    """
     Convert a string that looks like a float to a float.
-    '''
+    """
     return float(re.sub(r'\s*', '', t[0]))
 
 
 def to_int(t):
-    '''
+    """
     Convert a string that looks like an int to an int.
-    '''
+    """
     return int(re.sub(r'\s*', '', t[0]))
 
 
@@ -77,15 +77,13 @@ ESCAPE_SEQUENCE_RE = re.compile(r'''
     | \\[0-7]{1,3}     # Octal escapes
     | \\N\{[^}]+\}     # Unicode characters by name
     | \\[\\'"abfnrtv]  # Single-character escapes
-    )''',
-    re.UNICODE | re.VERBOSE
-)
+    )''', re.UNICODE | re.VERBOSE)
 
 
 def decode_escapes(s):
-    '''
+    """
     Decode string escape sequences.
-    '''
+    """
     def decode_match(match):
         return codecs.decode(match.group(0), 'unicode-escape')
     result = ESCAPE_SEQUENCE_RE.sub(decode_match, s)
@@ -138,8 +136,8 @@ value << (dict_ | list_ | float_ | int_ | string_ |
           null | true | false | illegal)
 
 
-def default_resolver(value):
-    '''
+def default_resolver(value_):
+    """
     Default resolver for illegal values.
 
     Case-insensitively resolves
@@ -154,8 +152,8 @@ def default_resolver(value):
       counterparts
 
     All other strings are returned unchanged.
-    '''
-    low = value.lower()
+    """
+    low = value_.lower()
     if low in ['true', 'yes', 'on']:
         return True
     if low in ['false', 'no', 'off']:
@@ -167,11 +165,11 @@ def default_resolver(value):
         return float(re.sub(r'\s+', '', low))
     except ValueError:
         pass
-    return decode_escapes(value)
+    return decode_escapes(value_)
 
 
 def resolve(data, resolver=default_resolver):
-    '''
+    """
     Recursively resolve illegal values.
 
     ``data`` is a potentially nested Python value as returned by
@@ -181,28 +179,27 @@ def resolve(data, resolver=default_resolver):
 
     All instances of ``IllegalValue`` in ``data`` are replaced by the
     result of feeding them into ``resolver``.
-    '''
+    """
     if isinstance(data, list):
         return [resolve(item, resolver) for item in data]
     if isinstance(data, dict):
-        return {resolve(key, resolver): resolve(value, resolver) for key, value in iteritems(data)}
+        return {resolve(key, resolver): resolve(value_, resolver) for key, value_ in iteritems(data)}
     if isinstance(data, IllegalValue):
         return resolver(data.source)
     return data
 
 
 def parse(s, resolver=default_resolver):
-    '''
+    """
     Parse a string that contains barely JSON.
 
     When values that are illegal in JSON are encountered then they are
     by default heuristicaly resolved to a suitable Python type (see
     ``resolve`` and ``default_resolver``). Set ``resolver`` to a custom
     callback or to a falsy value to modify or disable that mechanism.
-    '''
+    """
     parsed = value.parseString(s, parseAll=True)
     data = parsed.asList()[0]
     if resolver:
         data = resolve(data, resolver=resolver)
     return data
-

--- a/tests/test_barely_json.py
+++ b/tests/test_barely_json.py
@@ -10,9 +10,7 @@ from six.moves import zip
 
 from barely_json import *
 
-
 empty = IllegalValue('')
-
 
 STRING_ESCAPE_TESTS = [
     r'\t', '\t',
@@ -42,16 +40,16 @@ STRING_ESCAPE_TESTS = [
 
 
 def pairwise(iterable):
-    '''
+    """
     s -> (s0, s1), (s2, s3), (s4, s5), ...
-    '''
+    """
     a = iter(iterable)
     return zip(a, a)
 
 
 class TestParse(object):
-
-    def check(self, *args, **kwargs):
+    @staticmethod
+    def check(*args, **kwargs):
         resolver = kwargs.pop('resolver', None)
         for code, expected in pairwise(args):
             assert parse(code, resolver=resolver) == expected
@@ -149,10 +147,10 @@ class TestParse(object):
 
 
 class TestDefaultResolver(object):
-
-    def check(self, *args):
-        for value, expected in pairwise(args):
-            assert default_resolver(value) == expected
+    @staticmethod
+    def check(*args):
+        for value_, expected in pairwise(args):
+            assert default_resolver(value_) == expected
 
     def test_empty(self):
         self.check('', '')
@@ -209,11 +207,11 @@ class TestDefaultResolver(object):
 
 
 class TestResolve(object):
-
-    def check(self, *args, **kwargs):
+    @staticmethod
+    def check(*args, **kwargs):
         resolver = kwargs.pop('resolver', default_resolver)
-        for value, expected in pairwise(args):
-            assert resolve(value, resolver=resolver) == expected
+        for value_, expected in pairwise(args):
+            assert resolve(value_, resolver=resolver) == expected
 
     def test_list(self):
         self.check(
@@ -246,7 +244,11 @@ class TestResolve(object):
         )
 
     def test_custom_resolver(self):
-        resolver = lambda value: 1 if value == 'one' else value
+        def resolver(value_):
+            if value_ == 'one':
+                return 1
+            return value_
+
         self.check(
             IllegalValue('one'), 1,
             IllegalValue('true'), 'true',
@@ -257,3 +259,5 @@ class TestResolve(object):
             resolver=resolver
         )
 
+    def test_str_illegal(self):
+        assert str(IllegalValue('one')) == 'one'

--- a/tests/test_barely_json.py
+++ b/tests/test_barely_json.py
@@ -40,9 +40,9 @@ STRING_ESCAPE_TESTS = [
 
 
 def pairwise(iterable):
-    """
+    '''
     s -> (s0, s1), (s2, s3), (s4, s5), ...
-    """
+    '''
     a = iter(iterable)
     return zip(a, a)
 
@@ -149,8 +149,8 @@ class TestParse(object):
 class TestDefaultResolver(object):
     @staticmethod
     def check(*args):
-        for value_, expected in pairwise(args):
-            assert default_resolver(value_) == expected
+        for value, expected in pairwise(args):
+            assert default_resolver(value) == expected
 
     def test_empty(self):
         self.check('', '')
@@ -210,8 +210,8 @@ class TestResolve(object):
     @staticmethod
     def check(*args, **kwargs):
         resolver = kwargs.pop('resolver', default_resolver)
-        for value_, expected in pairwise(args):
-            assert resolve(value_, resolver=resolver) == expected
+        for value, expected in pairwise(args):
+            assert resolve(value, resolver=resolver) == expected
 
     def test_list(self):
         self.check(
@@ -244,10 +244,10 @@ class TestResolve(object):
         )
 
     def test_custom_resolver(self):
-        def resolver(value_):
-            if value_ == 'one':
+        def resolver(value):
+            if value == 'one':
                 return 1
-            return value_
+            return value
 
         self.check(
             IllegalValue('one'), 1,
@@ -259,5 +259,7 @@ class TestResolve(object):
             resolver=resolver
         )
 
+
+class TestIllegalValue(object):
     def test_str_illegal(self):
         assert str(IllegalValue('one')) == 'one'


### PR DESCRIPTION
Hey @torfsen 

This PR consists of mainly 4 modifications:

- [PEP-257](https://www.python.org/dev/peps/pep-0257/#one-line-docstrings): Using triple double quoted docstring.
- `str` function of `IllegalValue` was broken.
- Using `staticmethod` wherever applicable
- Renaming Shadowed variables.

Thanks. 
